### PR TITLE
Add Xash3D FWGS Engine support

### DIFF
--- a/Admin/Package/Screens/MonitoringTestScreen.php
+++ b/Admin/Package/Screens/MonitoringTestScreen.php
@@ -96,6 +96,7 @@ class MonitoringTestScreen extends Screen
                             'auto' => __('monitoring.admin.protocol_auto'),
                             'source' => 'Source Engine',
                             'goldsrc' => 'GoldSource (CS 1.6)',
+                            'xash3d' => 'Xash3D FWGS Engine',
                             'minecraft' => 'Minecraft',
                             'samp' => 'SA-MP',
                             'gta5' => 'GTA V (FiveM/RageMP)',
@@ -175,6 +176,7 @@ class MonitoringTestScreen extends Screen
             $protocolMap = [
                 'source' => '730',
                 'goldsrc' => '10',
+                'xash3d' => 'xash3d',
                 'minecraft' => 'minecraft',
                 'samp' => 'samp',
                 'gta5' => 'gta5',

--- a/Resources/views/admin/test-result.blade.php
+++ b/Resources/views/admin/test-result.blade.php
@@ -162,13 +162,19 @@
                 </div>
                 <div class="mtest__players mtest__players--simple">
                     @foreach (array_slice($playersData, 0, 20) as $player)
+                        @php
+                            // Normalise keys — formatPlayersData stores Name/Score/Time (capital),
+                            // but some drivers return name/score/time (lowercase)
+                            $playerName  = $player['Name']  ?? $player['name']  ?? null;
+                            $playerScore = $player['Score'] ?? $player['score'] ?? null;
+                            $playerTime  = $player['Time']  ?? $player['time']  ?? null;
+                        @endphp
                         <div class="mtest__player mtest__player--simple">
-                            <span class="mtest__player-name">{{ $player['name'] ?? 'Unknown' }}</span>
-                            @if (isset($player['score']))
-                                <span class="mtest__player-score">{{ $player['score'] }}</span>
-                            @endif
-                            @if (isset($player['time']))
-                                <span class="mtest__player-time">{{ gmdate('H:i:s', $player['time'] ?? 0) }}</span>
+                            <span class="mtest__player-name">
+                                {{ $playerName ?? 'Unknown' }}@if ($playerScore !== null) <span class="mtest__player-score">({{ $playerScore }})</span>@endif
+                            </span>
+                            @if ($playerTime !== null)
+                                <span class="mtest__player-time">{{ gmdate('H:i:s', (int) $playerTime) }}</span>
                             @endif
                         </div>
                     @endforeach
@@ -483,10 +489,20 @@
 
 .mtest__players--simple .mtest__player {
     border-left: none;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .mtest__player--simple {
     padding: 0.5rem 1rem;
+}
+
+.mtest__player-stats-simple {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    flex-shrink: 0;
 }
 
 .mtest__player-score,
@@ -494,6 +510,7 @@
     font-size: 0.8125rem;
     color: var(--text-400);
     font-family: var(--font-mono, monospace);
+    text-align: right;
 }
 
 .mtest__more {

--- a/Services/MapImageService.php
+++ b/Services/MapImageService.php
@@ -45,7 +45,13 @@ class MapImageService
 
     protected function getMapImagePath(ServerStatus $status): string
     {
-        $mod = preg_replace('/[^a-zA-Z0-9_\-]/', '', $status->server->mod);
+        $mod = $status->server->mod;
+
+        if ($mod === 'xash3d') {
+            $mod = in_array($status->game, ['cstrike', 'czero'], true) ? '10' : null;
+        }
+
+        $mod = preg_replace('/[^a-zA-Z0-9_\-]/', '', $mod ?? '');
         $map = preg_replace('/[^a-zA-Z0-9_\-]/', '', $status->map ?? '-');
 
         return 'assets/img/maps/' . $mod . '/' . $map . '.webp';

--- a/Services/MonitoringPingService.php
+++ b/Services/MonitoringPingService.php
@@ -19,7 +19,7 @@ class MonitoringPingService
     private const PING_TIMEOUT = 2;
 
     /** @var string[] Game mods that have no TCP listener — must use UDP probe */
-    private const UDP_ONLY_MODS = ['samp', 'minecraft_bedrock'];
+    private const UDP_ONLY_MODS = ['samp', 'minecraft_bedrock', 'xash3d'];
 
     /** @var string[] Game mods queried via HTTP */
     private const HTTP_MODS = ['gta5', 'fivem', 'redm'];
@@ -180,6 +180,11 @@ class MonitoringPingService
             $header .= chr(($port >> 8) & 0xFF);
 
             return $header . 'i';
+        }
+
+        // Xash3D FWGS — "info 49" out-of-band query
+        if ($mod === 'xash3d') {
+            return "\xFF\xFF\xFF\xFFinfo 49";
         }
 
         // Minecraft Bedrock (RakNet Unconnected Ping)


### PR DESCRIPTION
- Added Xash3D FWGS Engine as a protocol option in the test connection screen
- Added UDP ping support for Xash3D servers (info 49 probe packet)
- Fixed player names showing as "Unknown" in test result view (capitalised vs lowercase key mismatch in formatPlayersData)
- Map images for Xash3D servers running cstrike/czero now reuse existing CS 1.6 assets instead of falling back to the CS2 default